### PR TITLE
Support loading environment variables from .env file

### DIFF
--- a/Bin/openhab-cli
+++ b/Bin/openhab-cli
@@ -86,6 +86,12 @@ if [ -r "$OPENHAB_CONF/default" ]; then
   . "$OPENHAB_CONF/default"
 fi
 
+if [ -r "$OPENHAB_CONF/.env" ]; then
+  set -a
+  . "$OPENHAB_CONF/.env"
+  set +a
+fi
+
 option="$1"
 shift
 

--- a/Formula/openhab-milestone.rb
+++ b/Formula/openhab-milestone.rb
@@ -81,6 +81,7 @@ class OpenhabMilestone < Formula
         set -a
         . #{env_file}
         . #{openhab_conf}/default
+        [ -r #{openhab_conf}/.env ] && . #{openhab_conf}/.env
         set +a
         # Launch openHAB
         echo $(date +%Y-%m-%dT%H:%M:%S) Launching the openHAB runtime...


### PR DESCRIPTION
This adds support for loading env variables from a `$(hombrew --prefix)/etc/openhab/.env` file.